### PR TITLE
Use buf-action in CI

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -1,0 +1,15 @@
+name: buf
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v0.1
+        with:
+          version: 1.32.2

--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -1,7 +1,9 @@
 name: buf
 on:
+  push:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  delete:
 permissions:
   contents: read
   pull-requests: write
@@ -13,3 +15,4 @@ jobs:
       - uses: bufbuild/buf-action@v0.1
         with:
           version: 1.32.2
+          token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,36 +1,16 @@
 name: ci
 on:
   push:
-permissions: read-all
+permissions:
+  contents: read
 jobs:
-  lint:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/Makefile') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
           go-version: stable
-          check-latest: true
-      - name: Build and lint
-        run: |
-          make
-  breaking:
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.32.0-beta.1
-        with:
-          github_token: ${{ github.token }}
-      - uses: bufbuild/buf-breaking-action@v1
-        with:
-          against: https://github.com/bufbuild/confluent-proto.git#branch=main
+          cache-dependency-path: Makefile
+      - run: make
+      - run: make checkgenerate

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,15 @@ COPYRIGHT_YEARS := 2023
 LICENSE_IGNORE := --ignore /testdata/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
-BUF_VERSION := v1.32.0-beta.1
+BUF_VERSION ?= 1.32.2
 
 .PHONY: help
 help: ## Describe useful make targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-30s %s\n", $$1, $$2}'
 
 .PHONY: all
-all: ## Build and lint (default)
+all: ## Generate, build and lint (default)
+	$(MAKE) generate
 	$(MAKE) build
 	$(MAKE) lint
 
@@ -54,9 +55,9 @@ checkgenerate:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN="$(abspath $(@D))" $(GO) install github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
+	GOBIN="$(abspath $(@D))" $(GO) install github.com/bufbuild/buf/cmd/buf@v$(BUF_VERSION)
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN="$(abspath $(@D))" $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@$(BUF_VERSION)
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v$(BUF_VERSION)


### PR DESCRIPTION
This PR updates CI to use the new buf-action, replacing the current lint and breaking change detection. We currently don't sync this repository with the BSR. We need to add `BUF_TOKEN` secrets to get this behaviour.

Tasks remaining:
- [x] remove GitHub status requirement for `lint` and `breaking`
- [x] sync changes to the BSR

Closes #11 