### PR TITLE
Cleanup documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Buf Technologies, Inc.
+   Copyright 2023-2024 Buf Technologies, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ This module contains Protobuf extensions for integration with the Confluent Sche
 
 ## Usage
 
+Add a dependency on this module in your `buf.yaml`:
+
+```yaml
+version: v2
+deps:
+  # For enterprise users: replace "buf.build" with the hostname of your instance.
+  - buf.build/bufbuild/confluent
+```
+
+Add this dependency to your `buf.lock`:
+
+```bash
+buf dep update
+```
+
 To specify the mapping between a given subject and a Protobuf message, set the
 `buf.confluent.v1.Subject`. For example, the following defines a mapping between the
 `acme.v1.EmailUpdated` message and the Confluent Schema Registry subject `email-updated-value`:

--- a/README.md
+++ b/README.md
@@ -1,43 +1,50 @@
 # bufbuild/confluent
 
 [![Build](https://github.com/bufbuild/confluent-proto/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/bufbuild/confluent-proto/actions/workflows/ci.yaml)
-![GitHub release (with filter)](https://img.shields.io/github/v/release/bufbuild/confluent-proto)
+[![BSR](https://img.shields.io/badge/BSR-Module-0C65EC)](https://buf.build/bufbuild/confluent)
+![License](https://img.shields.io/github/license/bufbuild/confluent-proto)
 ![GitHub](https://img.shields.io/github/license/bufbuild/confluent-proto)
 
 This module contains Protobuf extensions for integration with the Confluent Schema Registry.
 
 ## Usage
 
-To integrate with the Confluent Schema Registry, extend the
-`buf.confluent.v1.subject` extension on a protobuf Message.
-For example, see the `demo/analytics/event.proto` message below, which defines
-a mapping between the message `demo.analytics.MyEvent` and the Confluent Schema
-Registry subject `my-event-value`.
+To specify the mapping between a given subject and a Protobuf message, set the
+`buf.confluent.v1.Subject`. For example, the following defines a mapping between the
+`acme.v1.EmailUpdated` message and the Confluent Schema Registry subject `email-updated-value`:
 
 ```proto
 syntax = "proto3";
 
-package demo.analytics;
+package acme.v1;
 
 import "buf/confluent/v1/extensions.proto";
 
-message MyEvent {
-  string a_string = 1;
-  bytes some_data = 2;
-
-  // Define one or more options to associate protobuf messages with Kafka topics.
+// An event where an email address was updated for a given user.
+message EmailUpdated {
   option (buf.confluent.v1.subject) = {
-    // The BSR's instance name for its Confluent Schema Registry integration.
-    // These are provisioned in the Admin Settings of the BSR.
-    instance_name: "prod",
-    // The name of the subject to associate the message.
-    // The '-value' suffix is used for messages used as Kafka topic values.
-    // The '-key' suffix is used for Kafka topic keys.
-    name: "my-event-value",
+    // The user-specified name for the Confluent Schema Registry instance within the BSR.
+    // Instances are managed within BSR admin settings.
+    instance_name: "prod"
+    // The subject's name as determined by the subject naming strategy.
+    //
+    // See https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#subject-name-strategy
+    // for more details.
+
+    // The default subject name strategy is TopicNameStrategy, which appends either "-key" or
+    // "-value" to a Kafka topic's name to create the subject name.
+    name: "email-updated-value"
   };
+
+  // The ID of the user associated with this email address update.
+  string id = 1;
+  // The old email address.
+  string old_email_address = 2;
+  // The new email address.
+  string new_email_address = 3;
 }
 ```
 
-When a Buf module is pushed to the BSR with the Confluent integration enabled,
-this will automatically create a subject named `my-event-value` associated with
-the `demo.analytics.MyEvent` message on the instance name `prod`.
+When a Buf module is pushed to the BSR with the Confluent integration enabled, this will
+automatically create a subject named `email-updated-value` associated with this message on the
+`prod` Confluent Schema Registry instance.

--- a/buf.yaml
+++ b/buf.yaml
@@ -2,7 +2,8 @@ version: v2
 name: buf.build/bufbuild/confluent
 lint:
   use:
-    - DEFAULT
+    - STANDARD
+    - COMMENTS
   disallow_comment_ignores: true
 breaking:
   use:

--- a/buf/confluent/v1/extensions.proto
+++ b/buf/confluent/v1/extensions.proto
@@ -1,4 +1,4 @@
-// Copyright 2023 Buf Technologies, Inc.
+// Copyright 2023-2024 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,32 +14,31 @@
 
 syntax = "proto3";
 
+// Defines an extension to map a Protouf message to a Confluent subject.
 package buf.confluent.v1;
 
 import "google/protobuf/descriptor.proto";
 
-// Subject declares a unique mapping between a protobuf Message and a subject
-// name with an instance of the Confluent Schema Registry integration in the
-// BSR.
+// Declares a unique mapping between a Protobuf Message and a subject name with an instance of the
+// Confluent Schema Registry integration in the BSR.
 //
-// For more details on the Confluent Schema Registry model, see:
-// https://docs.confluent.io/platform/current/schema-registry/fundamentals/index.html#schemas-subjects-and-topics
+// See https://docs.confluent.io/platform/current/schema-registry/fundamentals/index.html#schemas-subjects-and-topics
+// for more details on the Confluent Schema Registry model.
 message Subject {
-  // instance_name is the user-specified name for the Confluent Schema Registry
-  // instance within the BSR. Instances are managed within Admin Settings in the BSR.
+  // The user-specified name for the Confluent Schema Registry instance within the BSR.
+  // Instances are managed within BSR admin settings.
   string instance_name = 1;
-  // name is the subject's name, determined by the subject naming strategy. See
-  // the Confluent documentation for more details:
-  // https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#subject-name-strategy
+  // The subject's name as determined by the subject naming strategy.
   //
-  // The default subject name strategy is TopicNameStrategy, which appends
-  // either '-key' or '-value' to a Kafka topic's name to create the subject
-  // name.
+  // See https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#subject-name-strategy
+  // for more details.
+  //
+  // The default subject name strategy is TopicNameStrategy, which appends either "-key" or
+  // "-value" to a Kafka topic's name to create the subject name.
   string name = 2;
 }
 
 extend google.protobuf.MessageOptions {
-  // subject identifies Confluent Schema Registry subjects whose schema is
-  // defined by the containing message.
+  // The Confluent Schema Registry subjects whose schema is defined by the containing message.
   repeated Subject subject = 1158;
 }


### PR DESCRIPTION
- Clarify `README.md` including using a more realistic example.
- Clarify and expand API documentation.
- Update `buf.yaml` to include enforcement for comments, and to use the new `STANDARD` category.
- Update copyright years to 2023-2024.
- Update `Makefile` to be a newer version of what we use for proto-only repositories.